### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-static-web-apps-ambitious-ground-09fc3450f.yml
+++ b/.github/workflows/azure-static-web-apps-ambitious-ground-09fc3450f.yml
@@ -50,6 +50,8 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job
+    permissions:
+      contents: read
     steps:
       - name: Close Pull Request
         id: closepullrequest


### PR DESCRIPTION
Potential fix for [https://github.com/elijah-chou/MyPage/security/code-scanning/1](https://github.com/elijah-chou/MyPage/security/code-scanning/1)

To fix the problem, the `close_pull_request_job` job must define an explicit `permissions` block so that `GITHUB_TOKEN` has only the minimal required rights. Since this job just calls `Azure/static-web-apps-deploy@v1` using an Azure API token from secrets and does not modify the repo, it should be safe to set `contents: read` (or even `contents: none`; however, `contents: read` is a conservative minimal standard suggested by GitHub). This mirrors the least‑privilege approach already used in `build_and_deploy_job`.

Concretely, in `.github/workflows/azure-static-web-apps-ambitious-ground-09fc3450f.yml`, under `close_pull_request_job:` (around line 49), add a `permissions:` block at the same indentation as `runs-on` and `name`. The block should specify `contents: read`. No imports or additional methods are required because this is a YAML workflow file, and we are only adding configuration keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
